### PR TITLE
fcm mobile priority 반영

### DIFF
--- a/src/main/java/com/allknu/fcm/core/types/AndroidPriority.java
+++ b/src/main/java/com/allknu/fcm/core/types/AndroidPriority.java
@@ -1,0 +1,14 @@
+package com.allknu.fcm.core.types;
+
+import lombok.Getter;
+
+@Getter
+public enum AndroidPriority {
+    NORMAL("NORMAL"),
+    HIGH("HIGH");
+
+    private String value;
+    AndroidPriority(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/allknu/fcm/core/types/ApnsPriority.java
+++ b/src/main/java/com/allknu/fcm/core/types/ApnsPriority.java
@@ -1,0 +1,14 @@
+package com.allknu.fcm.core.types;
+
+import lombok.Getter;
+
+@Getter
+public enum ApnsPriority {
+    FIVE("5"),
+    TEN("10");
+
+    private String value;
+    ApnsPriority(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/allknu/fcm/core/types/ApnsPushType.java
+++ b/src/main/java/com/allknu/fcm/core/types/ApnsPushType.java
@@ -1,0 +1,19 @@
+package com.allknu.fcm.core.types;
+
+import lombok.Getter;
+
+@Getter
+public enum ApnsPushType {
+    ALERT("alert"),
+    BACKGROUND("background"),
+    LOCATION("location"),
+    VOIP("voip"),
+    COMPLICATION("complication"),
+    FILE_PROVIDER("fileprovider"),
+    MDM("mdm");
+
+    private String value;
+    ApnsPushType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/allknu/fcm/kafka/MessageConsumer.java
+++ b/src/main/java/com/allknu/fcm/kafka/MessageConsumer.java
@@ -1,8 +1,8 @@
 package com.allknu.fcm.kafka;
 
 import com.allknu.fcm.core.types.SubscribeType;
+import com.allknu.fcm.kafka.dto.FCMMobileMessage;
 import com.allknu.fcm.kafka.dto.FCMSubscribeMessage;
-import com.allknu.fcm.kafka.dto.FCMWebMessage;
 import com.allknu.fcm.utils.FCMUtil;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +22,17 @@ public class MessageConsumer {
     private final FCMUtil fcmUtil;
 
     @KafkaListener(topics = "fcm", groupId = "all-knu-fcm", containerFactory = "fcmRequestMessageListener")
-    public void consume(@Payload FCMWebMessage message, @Headers MessageHeaders headers) throws IOException {
+    public void consume(@Payload FCMMobileMessage message, @Headers MessageHeaders headers) throws IOException {
         System.out.println(String.format("Consumed message : %s", message.getBody()));
 
         try {
-            fcmUtil.sendFCMToTopics(message);
+            fcmUtil.sendFCMToTopics(message.getSubscribeTypes(),
+                    message.getTitle(),
+                    message.getBody(),
+                    message.getClickLink(),
+                    message.getApnsPushType(),
+                    message.getApnsPriority(),
+                    message.getAndroidPriority());
         }catch (FirebaseMessagingException firebaseMessagingException) {
             System.out.println(firebaseMessagingException);
         }

--- a/src/main/java/com/allknu/fcm/kafka/dto/FCMMobileMessage.java
+++ b/src/main/java/com/allknu/fcm/kafka/dto/FCMMobileMessage.java
@@ -1,0 +1,28 @@
+package com.allknu.fcm.kafka.dto;
+
+import com.allknu.fcm.core.types.AndroidPriority;
+import com.allknu.fcm.core.types.ApnsPriority;
+import com.allknu.fcm.core.types.ApnsPushType;
+import com.allknu.fcm.core.types.SubscribeType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FCMMobileMessage {
+    private List<SubscribeType> subscribeTypes; //보내고자하는 구독 유형 리스트
+    private String title;
+    private String body;
+    private String clickLink;
+
+    private ApnsPushType apnsPushType;
+    private ApnsPriority apnsPriority;
+    private AndroidPriority androidPriority;
+}
+

--- a/src/main/java/com/allknu/fcm/utils/FCMUtil.java
+++ b/src/main/java/com/allknu/fcm/utils/FCMUtil.java
@@ -1,11 +1,14 @@
 package com.allknu.fcm.utils;
 
+import com.allknu.fcm.core.types.AndroidPriority;
+import com.allknu.fcm.core.types.ApnsPriority;
+import com.allknu.fcm.core.types.ApnsPushType;
 import com.allknu.fcm.core.types.SubscribeType;
 import com.allknu.fcm.kafka.dto.FCMWebMessage;
 import com.google.firebase.messaging.*;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -43,14 +46,33 @@ public class FCMUtil {
 
     // 공식 문서에 보면 토픽 지정 보내기, 여러 토큰에 한번에 보내기가 있다. 필요할 때마다 추가해 사용하자드
     //특정 토큰에 메시지 전송
-    public void sendToOneToken(String targetToken, String title, String body, String clickLink) throws FirebaseMessagingException {
+    public void sendToOneToken(String targetToken, String title, String body, String clickLink, ApnsPushType apnsPushType, ApnsPriority apnsPriority, AndroidPriority androidPriority) throws FirebaseMessagingException {
         // [START send_to_token]
         // This registration token comes from the client FCM SDKs.
         String registrationToken = targetToken;
 
+        // android 알림 설정
+        AndroidConfig.Builder androidConfigBuilder = AndroidConfig.builder();
+        // 안드로이드 우선순위 설정
+        if(androidPriority != null) {
+            androidConfigBuilder.setPriority(AndroidConfig.Priority.valueOf(androidPriority.getValue()));
+        } else androidConfigBuilder.setPriority(AndroidConfig.Priority.HIGH);
+
+        // ios 알림 설정
+        if(apnsPushType == null) apnsPushType = ApnsPushType.BACKGROUND; // 디폴트
+        // ios 푸시타입 설정
+        ApnsConfig.Builder apnsConfigBuilder = ApnsConfig.builder()
+                .putHeader("apns-push-type", apnsPushType.getValue());
+        // ios 우선순위 설정
+        if(apnsPriority != null) {
+            apnsConfigBuilder.putHeader("apns-priority", apnsPriority.getValue());
+        } else apnsConfigBuilder.putHeader("apns-priority", ApnsPriority.FIVE.getValue());
+
         // See documentation on defining a message payload.
         Message message = Message.builder()
                 .setToken(registrationToken)
+                .setAndroidConfig(androidConfigBuilder.build())
+                .setApnsConfig(apnsConfigBuilder.build())
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
@@ -71,30 +93,50 @@ public class FCMUtil {
     }
 
     //토픽들에게 메시지 전송
-    public void sendFCMToTopics(FCMWebMessage fcmWebMessage) throws FirebaseMessagingException {
+    public void sendFCMToTopics(List<SubscribeType> subscribeTypes, String title, String body, String clickLink, ApnsPushType apnsPushType, ApnsPriority apnsPriority, AndroidPriority androidPriority) throws FirebaseMessagingException {
         // Define a condition which will send to devices which are subscribed
         //String condition = "'stock-GOOG' in topics || 'industry-tech' in topics";
-        String condition = "";
-        if(fcmWebMessage.getSubscribeTypes().size() > 0) {
-            condition = "'" + fcmWebMessage.getSubscribeTypes().get(0).toString() + "' in topics";
+
+        StringBuilder conditionBuilder = new StringBuilder();
+        if(subscribeTypes.size() > 0) {
+            conditionBuilder.append("'" + subscribeTypes.get(0).toString() + "' in topics");
         }
-        for(int i = 1 ; i < fcmWebMessage.getSubscribeTypes().size() ; i++) {
+        for(int i = 1 ; i < subscribeTypes.size() ; i++) {
             if(i >= 5) break; // 주제는 5개까지만 된다더라
-            condition = condition + " || '" + fcmWebMessage.getSubscribeTypes().get(i).toString() + "' in topics";
+            conditionBuilder.append(" || '" + subscribeTypes.get(i).toString() + "' in topics");
         }
+
+        // android 알림 설정
+        AndroidConfig.Builder androidConfigBuilder = AndroidConfig.builder();
+        // 안드로이드 우선순위 설정
+        if(androidPriority != null) {
+            androidConfigBuilder.setPriority(AndroidConfig.Priority.valueOf(androidPriority.getValue()));
+        } else androidConfigBuilder.setPriority(AndroidConfig.Priority.HIGH);
+
+        // ios 알림 설정
+        if(apnsPushType == null) apnsPushType = ApnsPushType.BACKGROUND; // 디폴트
+        // ios 푸시타입 설정
+        ApnsConfig.Builder apnsConfigBuilder = ApnsConfig.builder()
+                .putHeader("apns-push-type", apnsPushType.getValue());
+        // ios 우선순위 설정
+        if(apnsPriority != null) {
+            apnsConfigBuilder.putHeader("apns-priority", apnsPriority.getValue());
+        } else apnsConfigBuilder.putHeader("apns-priority", ApnsPriority.FIVE.getValue());
 
         // See documentation on defining a message payload.
         Message message = Message.builder()
+                .setAndroidConfig(androidConfigBuilder.build())
+                .setApnsConfig(apnsConfigBuilder.build())
                 .setNotification(Notification.builder()
-                        .setTitle(fcmWebMessage.getTitle())
-                        .setBody(fcmWebMessage.getBody())
+                        .setTitle(title)
+                        .setBody(body)
                         .build())
                 .setWebpushConfig(WebpushConfig.builder()
                         .setFcmOptions(WebpushFcmOptions.builder()
-                                .setLink(fcmWebMessage.getClickLink())
+                                .setLink(clickLink)
                                 .build())
                         .build())
-                .setCondition(condition)
+                .setCondition(conditionBuilder.toString())
                 .build();
 
         // Send a message to devices subscribed to the combination of topics
@@ -104,3 +146,4 @@ public class FCMUtil {
         System.out.println("Successfully sent message: " + response);
     }
 }
+

--- a/src/test/java/com/allknu/fcm/utils/FCMUtilTests.java
+++ b/src/test/java/com/allknu/fcm/utils/FCMUtilTests.java
@@ -1,7 +1,11 @@
 package com.allknu.fcm.utils;
 
+import com.allknu.fcm.core.types.AndroidPriority;
+import com.allknu.fcm.core.types.ApnsPriority;
+import com.allknu.fcm.core.types.ApnsPushType;
 import com.allknu.fcm.core.types.SubscribeType;
 import com.allknu.fcm.kafka.dto.FCMWebMessage;
+import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +33,7 @@ public class FCMUtilTests {
         //given
         //when
         try {
-            fcmUtil.sendToOneToken(targetToken,"hello", "world!","https://naver.com");
+            fcmUtil.sendToOneToken(targetToken,"hello", "world!","https://naver.com", ApnsPushType.BACKGROUND, ApnsPriority.FIVE, AndroidPriority.HIGH);
         }catch (FirebaseMessagingException firebaseMessagingException) {
             System.out.println(firebaseMessagingException);
         }
@@ -79,7 +83,7 @@ public class FCMUtilTests {
 
         //when
         try {
-            fcmUtil.sendFCMToTopics(fcmWebMessage);
+            fcmUtil.sendFCMToTopics(fcmWebMessage.getSubscribeTypes(), fcmWebMessage.getTitle(), fcmWebMessage.getBody(), fcmWebMessage.getClickLink(), ApnsPushType.BACKGROUND, ApnsPriority.FIVE, AndroidPriority.HIGH);
         }catch (FirebaseMessagingException firebaseMessagingException) {
             System.out.println(firebaseMessagingException);
         }


### PR DESCRIPTION
## 구현내용
#8 이슈 반영
kafka mobile fcm dto를 제작하고 이를 consumer에서 수신받아 fcm util을 호출해 모바일의 priority를 수정할 수 있도록 하였다.

### 학습 내용(optional)
어떤 기술써서 어떻게 했다. 에 대한 기술 설명

